### PR TITLE
Cog for archiving channels and categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# General
 *.pyc
 .*~
 __pycache__/*
 .env
 client_secrets.json
+**/venv
+
+# IDE-Specific
+**/.idea

--- a/bot.py
+++ b/bot.py
@@ -20,7 +20,8 @@ initial_extensions = ['misc',
                       'debris',
                       'admin',
                       'tags',
-                      'puzzle']
+                      'puzzle',
+                      'archive']
 
 # initial_extensions = ['puzzle','hunt']
 

--- a/cogs/archive.py
+++ b/cogs/archive.py
@@ -72,6 +72,12 @@ class ArchiveCog(commands.Cog):
                 msg.author.display_name,
                 msg.clean_content
             ])
+            for attachment in msg.attachments:
+                messages.append([
+                    '->',
+                    '->',
+                    '=IMAGE("' + attachment.url + '")'
+                ])
 
         sheet_key = max(sheet_url.split('/'), key=len)
         gclient = self.gclient()
@@ -82,8 +88,7 @@ class ArchiveCog(commands.Cog):
             sheet.clear()
         except WorksheetNotFound:
             sheet = wkbook.add_worksheet(channel.name, 1, 3)
-        sheet.insert_rows(messages)
-        request = {
+        resize_cols_request = {
             'requests': [{
                 'autoResizeDimensions': {
                     'dimensions': {
@@ -95,7 +100,14 @@ class ArchiveCog(commands.Cog):
                 }
             }]
         }
-        wkbook.batch_update(request)
+
+        sheet.insert_rows(messages, value_input_option='USER_ENTERED')
+        wkbook.batch_update(resize_cols_request)
+        #vals = sheet.get_all_values()
+        #for row in range(0, sheet.row_count + 2):
+        #    if vals[row][2].startswith('~ARCHIVE_IMG_URL~:'):
+        #        url = vals[row][2].replace('~ARCHIVE_IMG_URL~:', '')
+        #        sheet.insert
 
         await status.edit(content='Channel {} archived!'.format(channel.mention))
 

--- a/cogs/archive.py
+++ b/cogs/archive.py
@@ -1,0 +1,55 @@
+# puzzle.py
+
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+import os
+import gspread
+import random
+import json
+import numpy as np
+import datetime
+from utils.db import DBase
+from google.oauth2 import service_account
+
+
+# A cog for archiving channels and categories
+# !archive
+
+class ArchiveCog(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.mark = '✅'
+        # self.mark = '✔'
+
+        # TODO: has to be a less silly way to organize this
+        load_dotenv()
+        self.key = os.getenv('GOOGLE_CLIENT_SECRETS')
+        self.googledata = json.loads(self.key)
+        self.googledata['private_key'] = self.googledata['private_key'].replace("\\n", "\n")
+        scopes = [
+            'https://www.googleapis.com/auth/spreadsheets',
+            'https://www.googleapis.com/auth/drive'
+        ]
+        self.credentials = service_account.Credentials.from_service_account_info(self.googledata, scopes=scopes)
+
+    def gclient(self):
+        client = gspread.authorize(self.credentials)
+        return client
+
+    def channel_get_by_id(self, ctx, channelid):
+        try:
+            channel = discord.utils.get(ctx.guild.channels, id=channelid)
+            return channel
+        except:
+            return False
+
+    @commands.command(aliases=['arc'])
+    @commands.guild_only()
+    async def archive(self, ctx, *, query=None):
+        await ctx.send('archive active')
+
+def setup(bot):
+    bot.add_cog(ArchiveCog(bot))
+

--- a/db_launcher.py
+++ b/db_launcher.py
@@ -9,7 +9,7 @@ import os
 
 # check connection to database
 load_dotenv()
-DB_ADDRESS = os.getenv('DB_ADDRESS')
+DB_ADDRESS = os.getenv('DATABASE_URL')
 connection = psycopg2.connect(DB_ADDRESS, sslmode='prefer')
 print(connection.get_dsn_parameters(),"\n")
 


### PR DESCRIPTION
Adds `!archive` command with two options, `channel` and `category`, that takes a sheet URL as input.
- archive saved as one channel per tab, one message per row
- attached images are copied, but other attachments are not


Notes:
- `!archive category` takes a minimum of 3 seconds per channel, because of Sheets API rate limits
    - however, this means categories of any size can be archived without issue (tested with a full 50-channel category)
- command has not been tested with massive channels, since I don't have any on hand
    - since API calls are made per-channel, this should not create a problem with rate-limiting
    - however, if a channel is sufficiently massive, the Python VM may run out of memory. Under sane circumstances, this scenario should not be encountered, especially since all data is in text format