### PR TITLE
Fix dep again for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ discord.py==2.1.0
 python-dotenv==1.0.1
 asyncio==3.4.3
 regex==2023.12.25
-numpy==1.26.0
+numpy>=1.24.0
 mechanize==0.4.9
 requests==2.32.4
 gspread==5.12.4
 datetime==5.4
 google-auth==2.27.0
 boto3==1.26.28
-matplotlib==3.8.2
+matplotlib>=3.7.0
 pillow==10.3.0
 


### PR DESCRIPTION
The VM is running python 3.8 so some of these dependencies stopped at higher versions. We should probably upgrade the VM python but this is faster at the moment. 